### PR TITLE
Basic TravisCI config added

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: java
+jdk:
+  - oraclejdk8
+sudo: false
+install: true
+
+script: mvn test
+


### PR DESCRIPTION
TravisCI badge [![Build Status](https://travis-ci.org/eddiejaoude/Chorus.svg?branch=master)](https://travis-ci.org/eddiejaoude/Chorus) (but against my **fork**)

<img width="1350" alt="screenshot 2016-02-25 07 19 25" src="https://cloud.githubusercontent.com/assets/624760/13312636/29c1d078-db90-11e5-9bc5-c1d3d6a0c483.png">

You will need to login in **TravisCI** and add the source project, as I am only able to add my **forked** version. The **TravisCI** config will be the same. I have not put the *status badge* in the `README.md` as the *status badge* above is pointing to my **forked** build status.

