### PR TITLE
 "public static" fields should be constant

### DIFF
--- a/chorus-selftest/src/test/features/org/chorusbdd/chorus/selftest/executionlistener/ExecutionListenerOne.java
+++ b/chorus-selftest/src/test/features/org/chorusbdd/chorus/selftest/executionlistener/ExecutionListenerOne.java
@@ -45,9 +45,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public class ExecutionListenerOne implements ExecutionListener {
     
-    public static AtomicBoolean isTestsStartedCalled = new AtomicBoolean();
-    public static AtomicBoolean isFeatureStartedCalled = new AtomicBoolean();
-    public static AtomicBoolean isScenarioStartedCalled = new AtomicBoolean();
+    public static final AtomicBoolean isTestsStartedCalled = new AtomicBoolean();
+    public static final AtomicBoolean isFeatureStartedCalled = new AtomicBoolean();
+    public static final AtomicBoolean isScenarioStartedCalled = new AtomicBoolean();
 
     /**
      * @param testExecutionToken a token representing the current suite of tests starting execution

--- a/chorus-selftest/src/test/features/org/chorusbdd/chorus/selftest/executionlistener/ExecutionListenerTwo.java
+++ b/chorus-selftest/src/test/features/org/chorusbdd/chorus/selftest/executionlistener/ExecutionListenerTwo.java
@@ -45,9 +45,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public class ExecutionListenerTwo implements ExecutionListener {
     
-    public static AtomicBoolean isTestsStartedCalled = new AtomicBoolean();
-    public static AtomicBoolean isFeatureStartedCalled = new AtomicBoolean();
-    public static AtomicBoolean isScenarioStartedCalled = new AtomicBoolean();
+    public static final AtomicBoolean isTestsStartedCalled = new AtomicBoolean();
+    public static final AtomicBoolean isFeatureStartedCalled = new AtomicBoolean();
+    public static final AtomicBoolean isScenarioStartedCalled = new AtomicBoolean();
 
     /**
      * @param testExecutionToken a token representing the current suite of tests starting execution


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1444 - “"public static" fields should be constant”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1444
Please let me know if you have any questions.
Ayman Abdelghany.