### PR TITLE
 Utility classes should not have public constructors

### DIFF
--- a/chorus-results/src/main/java/org/chorusbdd/chorus/results/util/NetworkUtils.java
+++ b/chorus-results/src/main/java/org/chorusbdd/chorus/results/util/NetworkUtils.java
@@ -52,6 +52,9 @@ public class NetworkUtils {
         }
     }
 
+    private NetworkUtils() {
+    }
+
     public static String getHostname() {
         return hostname;
     }

--- a/chorus-results/src/main/java/org/chorusbdd/chorus/results/util/StackTraceUtil.java
+++ b/chorus-results/src/main/java/org/chorusbdd/chorus/results/util/StackTraceUtil.java
@@ -37,6 +37,9 @@ import java.io.PrintStream;
  */
 public class StackTraceUtil {
 
+    private StackTraceUtil() {
+    }
+
     public static String getStackTraceAsString(Throwable t) {
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         PrintStream p = new PrintStream(bos);

--- a/chorus-selftest/src/test/junit/org/chorusbdd/chorus/selftest/FileUtil.java
+++ b/chorus-selftest/src/test/junit/org/chorusbdd/chorus/selftest/FileUtil.java
@@ -43,6 +43,9 @@ import java.io.InputStreamReader;
  */
 public class FileUtil {
 
+    private FileUtil() {
+    }
+
     public static String readToString(InputStream is) throws IOException {
         StringBuilder sb = new StringBuilder();
         try {

--- a/chorus-selftest/src/test/junit/org/chorusbdd/chorus/selftest/SelftestUtils.java
+++ b/chorus-selftest/src/test/junit/org/chorusbdd/chorus/selftest/SelftestUtils.java
@@ -43,6 +43,9 @@ import java.io.FileReader;
  */
 public class SelftestUtils {
 
+    private SelftestUtils() {
+    }
+
     public static void checkFileContainsLine(String line, String path) {
            BufferedReader r = null;
            try {

--- a/chorus-util/src/main/java/org/chorusbdd/chorus/util/HandlerUtils.java
+++ b/chorus-util/src/main/java/org/chorusbdd/chorus/util/HandlerUtils.java
@@ -37,6 +37,9 @@ package org.chorusbdd.chorus.util;
  */
 public class HandlerUtils {
 
+    private HandlerUtils() {
+    }
+
     /**
      * Like Class.forName, but works for primitive types too
      *

--- a/chorus-util/src/main/java/org/chorusbdd/chorus/util/OSUtils.java
+++ b/chorus-util/src/main/java/org/chorusbdd/chorus/util/OSUtils.java
@@ -35,7 +35,10 @@ package org.chorusbdd.chorus.util;
  * Time: 09:02
  */
 public class OSUtils {
-    
+
+    private OSUtils() {
+    }
+
     public static boolean isWindows() {
         return System.getProperty("os.name").toLowerCase().indexOf("win") >= 0;
     }

--- a/chorus-util/src/main/java/org/chorusbdd/chorus/util/RegexpUtils.java
+++ b/chorus-util/src/main/java/org/chorusbdd/chorus/util/RegexpUtils.java
@@ -36,6 +36,9 @@ package org.chorusbdd.chorus.util;
 @SuppressWarnings("unchecked")
 public class RegexpUtils {
 
+    private RegexpUtils() {
+    }
+
     /**
      * Replace any special characters in a regex replacement string
      */


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.