### PR TITLE
Simplify the generics declaration by using the diamond operator ("<>") to reduce the verbosity of generics code.

### DIFF
--- a/chorus-config/src/main/java/org/chorusbdd/chorus/config/AbstractConfigSource.java
+++ b/chorus-config/src/main/java/org/chorusbdd/chorus/config/AbstractConfigSource.java
@@ -50,7 +50,7 @@ public abstract class AbstractConfigSource implements ConfigSource {
     protected List<String> getOrCreatePropertyList(Map<ConfigurationProperty, List<String>> propertyMap, ConfigurationProperty switchName) {
         List<String> tokens = propertyMap.get(switchName);
         if ( tokens == null) {
-            tokens = new ArrayList<String>();
+            tokens = new ArrayList<>();
             propertyMap.put(switchName, tokens);
         }
         return tokens;

--- a/chorus-config/src/main/java/org/chorusbdd/chorus/config/ConfigReader.java
+++ b/chorus-config/src/main/java/org/chorusbdd/chorus/config/ConfigReader.java
@@ -60,10 +60,10 @@ public class ConfigReader implements ConfigProperties {
     private String[] args;
 
     //the properties provided be each source
-    private Map<ConfigSource, Map<ConfigurationProperty, List<String>>> sourceToPropertiesMap = new HashMap<ConfigSource, Map<ConfigurationProperty, List<String>>>();
+    private Map<ConfigSource, Map<ConfigurationProperty, List<String>>> sourceToPropertiesMap = new HashMap<>();
 
     //the merged set of properties, after PropertySourceMode is applied
-    private Map<ConfigurationProperty, List<String>> propertyMap = new HashMap<ConfigurationProperty, List<String>>();
+    private Map<ConfigurationProperty, List<String>> propertyMap = new HashMap<>();
 
     //ordered list of property sources
     private ConfigSource[] propertySources;
@@ -96,7 +96,7 @@ public class ConfigReader implements ConfigProperties {
 
     public ConfigReader readConfiguration() throws InterpreterPropertyException {
         for ( ConfigSource s : propertySources) {
-            Map<ConfigurationProperty, List<String>> propertyMap = new HashMap<ConfigurationProperty, List<String>>();
+            Map<ConfigurationProperty, List<String>> propertyMap = new HashMap<>();
             propertyMap = s.parseProperties(propertyMap, args);
             sourceToPropertiesMap.put(s, propertyMap);
         }
@@ -137,7 +137,7 @@ public class ConfigReader implements ConfigProperties {
     private List<String> getOrCreatePropertyValues(ConfigurationProperty p) {
         List<String> vals = propertyMap.get(p);
         if ( vals == null) {
-            vals = new LinkedList<String>();
+            vals = new LinkedList<>();
             propertyMap.put(p, vals);
         }
         return vals;

--- a/chorus-config/src/test/junit/org/chorusbdd/chorus/config/CommandLineParserTest.java
+++ b/chorus-config/src/test/junit/org/chorusbdd/chorus/config/CommandLineParserTest.java
@@ -52,12 +52,12 @@ public class CommandLineParserTest {
 
     @Before
     public void doSetUp() {
-        propertyMap = new HashMap<ConfigurationProperty, List<String>>();
+        propertyMap = new HashMap<>();
     }
 
     @Test
     public void testArgWithNoValues() throws InterpreterPropertyException {
-        propertyMap = new HashMap<ConfigurationProperty, List<String>>();
+        propertyMap = new HashMap<>();
         Map<ConfigurationProperty, List<String>> parsedArgs = new CommandLineParser(TestConfigProperty.getAll()).parseProperties(propertyMap, TEST_ARGS);
         Assert.assertTrue("-showErrors flag not found", parsedArgs.containsKey(TestConfigProperty.SHOW_ERRORS));
     }

--- a/chorus-config/src/test/junit/org/chorusbdd/chorus/config/TestConfigProperty.java
+++ b/chorus-config/src/test/junit/org/chorusbdd/chorus/config/TestConfigProperty.java
@@ -203,7 +203,7 @@ public enum TestConfigProperty implements ConfigurationProperty {
     }
 
     public static List<ConfigurationProperty> getAll() {
-        List<ConfigurationProperty> l = new ArrayList<ConfigurationProperty>();
+        List<ConfigurationProperty> l = new ArrayList<>();
         Collections.addAll(l, values());
         return l;
     }

--- a/chorus-context/src/main/java/org/chorusbdd/chorus/context/ChorusContext.java
+++ b/chorus-context/src/main/java/org/chorusbdd/chorus/context/ChorusContext.java
@@ -50,9 +50,9 @@ public class ChorusContext implements Map<String, Object>, Serializable {
      */
     public static final String LAST_RESULT = "lastResult";
 
-    private static ThreadLocal<ChorusContext> threadLocal = new ThreadLocal<ChorusContext>();
+    private static ThreadLocal<ChorusContext> threadLocal = new ThreadLocal<>();
 
-    private Map<String, Object> state = new HashMap<String, Object>();
+    private Map<String, Object> state = new HashMap<>();
 
     private ChorusContext() {
     }

--- a/chorus-executionlistener/src/main/java/org/chorusbdd/chorus/executionlistener/ExecutionListenerSupport.java
+++ b/chorus-executionlistener/src/main/java/org/chorusbdd/chorus/executionlistener/ExecutionListenerSupport.java
@@ -45,7 +45,7 @@ import java.util.*;
  */
 public class ExecutionListenerSupport {
 
-    private List<ExecutionListener> listeners = new ArrayList<ExecutionListener>();
+    private List<ExecutionListener> listeners = new ArrayList<>();
 
     //
     // Execution event methods
@@ -119,7 +119,7 @@ public class ExecutionListenerSupport {
     }
 
     public List<ExecutionListener> getListeners() {
-        return new ArrayList<ExecutionListener>(listeners);
+        return new ArrayList<>(listeners);
     }
 
 }

--- a/chorus-handlers/src/main/java/org/chorusbdd/chorus/handlers/utils/HandlerPatterns.java
+++ b/chorus-handlers/src/main/java/org/chorusbdd/chorus/handlers/utils/HandlerPatterns.java
@@ -87,7 +87,7 @@ public class HandlerPatterns {
      */
     public static List<String> getProcessNames(String processNameList) {
         String[] processNames = processNameList.split(",");
-        List<String> results = new LinkedList<String>();
+        List<String> results = new LinkedList<>();
         for ( String p : processNames) {
             String processConfigName = p.trim();
             if ( processConfigName.length() > 0) {

--- a/chorus-interpreter/src/main/java/org/chorusbdd/chorus/interpreter/interpreter/ChorusInterpreter.java
+++ b/chorus-interpreter/src/main/java/org/chorusbdd/chorus/interpreter/interpreter/ChorusInterpreter.java
@@ -114,7 +114,7 @@ public class ChorusInterpreter {
         log.info("Running feature from file: " + feature.getFeatureFile() + config);
 
         //check that the required handler classes are all available and list them in order of precedence
-        List<Class> orderedHandlerClasses = new ArrayList<Class>();
+        List<Class> orderedHandlerClasses = new ArrayList<>();
         StringBuilder unavailableHandlersMessage = handlerClassDiscovery.findHandlerClasses(allHandlerClasses, feature, orderedHandlerClasses);
         boolean foundAllHandlerClasses = unavailableHandlersMessage.length() == 0;
 

--- a/chorus-interpreter/src/main/java/org/chorusbdd/chorus/interpreter/interpreter/ContextVariableStepExpander.java
+++ b/chorus-interpreter/src/main/java/org/chorusbdd/chorus/interpreter/interpreter/ContextVariableStepExpander.java
@@ -55,7 +55,7 @@ public class ContextVariableStepExpander {
         String action = step.getAction();
 
         Matcher m = p.matcher(action);
-        List<String> variables = new LinkedList<String>();
+        List<String> variables = new LinkedList<>();
 
         while(m.find()) {
             variables.add(m.group());

--- a/chorus-interpreter/src/main/java/org/chorusbdd/chorus/interpreter/interpreter/HandlerManager.java
+++ b/chorus-interpreter/src/main/java/org/chorusbdd/chorus/interpreter/interpreter/HandlerManager.java
@@ -53,7 +53,7 @@ public class HandlerManager {
     private ChorusLog log = ChorusLogFactory.getLog(HandlerManager.class);
     
     //retain ordering of handlers 
-    private final LinkedHashMap<Class, Object> featureScopedHandlers = new LinkedHashMap<Class, Object>();
+    private final LinkedHashMap<Class, Object> featureScopedHandlers = new LinkedHashMap<>();
     
     private final FeatureToken feature;
     private final List<Class> orderedHandlerClasses;
@@ -87,7 +87,7 @@ public class HandlerManager {
     }
     
     public List<Object> getOrCreateHandlersForScenario() throws Exception {
-        List<Object> handlerInstances = new ArrayList<Object>();
+        List<Object> handlerInstances = new ArrayList<>();
         
         for ( Class handlerClass : orderedHandlerClasses ) {
             Handler handlerAnnotation = (Handler) handlerClass.getAnnotation(Handler.class);
@@ -223,11 +223,11 @@ public class HandlerManager {
     private void injectResourceFields(Object handler, Iterable<Object> handlerInstances, Scope... scopes) {
         Class<?> featureClass = handler.getClass();
 
-        List<Field> allFields = new ArrayList<Field>();
+        List<Field> allFields = new ArrayList<>();
         addAllPublicFields(featureClass, allFields);
         log.trace("Now examining handler fields for ChorusResource annotation " + allFields);
 
-        HashSet<Scope> scopeSet = new HashSet<Scope>(Arrays.asList(scopes));
+        HashSet<Scope> scopeSet = new HashSet<>(Arrays.asList(scopes));
         for (Field field : allFields) {
             setChorusResource(handler, handlerInstances, field, scopeSet);
         }

--- a/chorus-interpreter/src/main/java/org/chorusbdd/chorus/interpreter/startup/ChorusConfigProperty.java
+++ b/chorus-interpreter/src/main/java/org/chorusbdd/chorus/interpreter/startup/ChorusConfigProperty.java
@@ -237,7 +237,7 @@ public enum ChorusConfigProperty implements ConfigurationProperty {
     }
 
     public static List<ConfigurationProperty> getAll() {
-        List<ConfigurationProperty> l = new ArrayList<ConfigurationProperty>();
+        List<ConfigurationProperty> l = new ArrayList<>();
         Collections.addAll(l, values());
         return l;
     }

--- a/chorus-interpreter/src/main/java/org/chorusbdd/chorus/interpreter/startup/ExecutionListenerFactory.java
+++ b/chorus-interpreter/src/main/java/org/chorusbdd/chorus/interpreter/startup/ExecutionListenerFactory.java
@@ -54,7 +54,7 @@ public class ExecutionListenerFactory {
     private ChorusLog log = ChorusLogFactory.getLog(ExecutionListenerFactory.class);
 
     public List<ExecutionListener> createExecutionListeners(ConfigProperties config) {
-        List<ExecutionListener> result = new ArrayList<ExecutionListener>();
+        List<ExecutionListener> result = new ArrayList<>();
 
         //we can have zero to many remote jmx execution listeners available
         addProxyForRemoteJmxListener(config.getValues(ChorusConfigProperty.JMX_LISTENER), result);

--- a/chorus-interpreter/src/main/java/org/chorusbdd/chorus/interpreter/startup/InterpreterOutputExecutionListener.java
+++ b/chorus-interpreter/src/main/java/org/chorusbdd/chorus/interpreter/startup/InterpreterOutputExecutionListener.java
@@ -132,7 +132,7 @@ public class InterpreterOutputExecutionListener extends AbstractChorusOutputWrit
         private AbstractToken lastToken;
 
         //cache any log output which we receive before the call to 'testsStarted', otherwise we'd miss some key startup output
-        private List<String> cachedLogOutput = new LinkedList<String>();
+        private List<String> cachedLogOutput = new LinkedList<>();
         private Throwable cachedThrowable;
 
         void setLastToken(AbstractToken lastToken) {

--- a/chorus-interpreter/src/test/junit/org/chorusbdd/chorus/interpreter/tagexpressions/TagExpressionEvaluatorTest.java
+++ b/chorus-interpreter/src/test/junit/org/chorusbdd/chorus/interpreter/tagexpressions/TagExpressionEvaluatorTest.java
@@ -53,7 +53,7 @@ public class TagExpressionEvaluatorTest {
     public void init() {
         evaluatorUnderTest = new TagExpressionEvaluator();
 
-        abcScenarioTags = new ArrayList<String>();
+        abcScenarioTags = new ArrayList<>();
         abcScenarioTags.add("@a");
         abcScenarioTags.add("@b");
         abcScenarioTags.add("@c");

--- a/chorus-parser/src/main/java/org/chorusbdd/chorus/parser/FeatureFileParser.java
+++ b/chorus-parser/src/main/java/org/chorusbdd/chorus/parser/FeatureFileParser.java
@@ -95,11 +95,11 @@ public class FeatureFileParser extends AbstractChorusParser<FeatureToken> {
         try (BufferedReader reader = new BufferedReader(r.get())) {
 
             //we need to run the feature using combined list of both global and feature local step macros
-            List<StepMacro> allStepMacro = new ArrayList<StepMacro>();
+            List<StepMacro> allStepMacro = new ArrayList<>();
             allStepMacro.addAll(globalStepMacro);
             allStepMacro.addAll(featureLocalStepMacro);
 
-            List<String> usingDeclarations = new ArrayList<String>();
+            List<String> usingDeclarations = new ArrayList<>();
             List<String> configurationNames = null;
 
             FeatureToken currentFeature = null;
@@ -421,7 +421,7 @@ public class FeatureFileParser extends AbstractChorusParser<FeatureToken> {
 
     private List<String> readTableRowData(String line, boolean blankValuesPermitted) {
         String[] tokens = line.trim().split("\\|");
-        List<String> rowData = new ArrayList<String>();
+        List<String> rowData = new ArrayList<>();
         for (int i = 0 ; i < tokens.length ; i ++) {
             String token = tokens[i].trim();
             //always skip any blank space before the first |
@@ -434,7 +434,7 @@ public class FeatureFileParser extends AbstractChorusParser<FeatureToken> {
 
     private List<String> readConfigurationNames(String line) {
         String[] names = line.trim().substring(KeyWord.Configurations.stringVal().length() + 1).split(",");
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         for (String name : names) {
             if (name.trim().length() > 0) {
                 list.add(name.trim());
@@ -460,7 +460,7 @@ public class FeatureFileParser extends AbstractChorusParser<FeatureToken> {
             return null;
         } else {
             String[] names = tags.trim().split(" ");
-            List<String> list = new ArrayList<String>();
+            List<String> list = new ArrayList<>();
             for (String name : names) {
                 String tagName = name.trim();
                 if (tagName.length() > 0 && tagName.startsWith("@")) {

--- a/chorus-parser/src/main/java/org/chorusbdd/chorus/parser/StepMacro.java
+++ b/chorus-parser/src/main/java/org/chorusbdd/chorus/parser/StepMacro.java
@@ -93,12 +93,12 @@ public class StepMacro {
     private ChorusLog log = ChorusLogFactory.getLog(StepMacro.class);
 
     private Pattern pattern;
-    private List<StepToken> steps = new ArrayList<StepToken>();
+    private List<StepToken> steps = new ArrayList<>();
 
     private Pattern variablePattern = Pattern.compile("<[\\w\\-_]+>");
     private Pattern groupPattern = Pattern.compile("<\\$\\d+>");
 
-    private Map<String, Integer> variableToGroupNumber = new HashMap<String, Integer>();
+    private Map<String, Integer> variableToGroupNumber = new HashMap<>();
 
     public StepMacro(String pattern) {
         pattern = replaceVariablesWithPatterns(pattern);

--- a/chorus-parser/src/main/java/org/chorusbdd/chorus/parser/StepMacroParser.java
+++ b/chorus-parser/src/main/java/org/chorusbdd/chorus/parser/StepMacroParser.java
@@ -61,7 +61,7 @@ public class StepMacroParser extends AbstractChorusParser<StepMacro> {
 
         try (BufferedReader reader = new BufferedReader(r.get())) {
 
-            List<StepMacro> result = new LinkedList<StepMacro>();
+            List<StepMacro> result = new LinkedList<>();
             reader.mark(MAX_LENGTH_CHARS);
 
             boolean readingStepMacro = false;

--- a/chorus-pathscanner/src/main/java/org/chorusbdd/chorus/pathscanner/ClasspathScanner.java
+++ b/chorus-pathscanner/src/main/java/org/chorusbdd/chorus/pathscanner/ClasspathScanner.java
@@ -69,7 +69,7 @@ public class ClasspathScanner {
     private static String[] classpathNames;
 
     public static Set<Class> doScan(ClassFilter classFilter) {
-        Set<Class> s = new HashSet<Class>();
+        Set<Class> s = new HashSet<>();
         try {
             for (String clazz : getClasspathClassNames()) {
                 //check the name/package first before we try class loading
@@ -113,7 +113,7 @@ public class ClasspathScanner {
 
     public static String[] getClasspathFileNames(FilenameFilter filter)
             throws ZipException, IOException {
-        final List<String> filenames = new ArrayList<String>();
+        final List<String> filenames = new ArrayList<>();
         for (String filename : getClasspathFileNames()) {
             if (filter.accept(filename)) {
                 filenames.add(filename);
@@ -145,7 +145,7 @@ public class ClasspathScanner {
 
     private static String[] findClassNames() throws IOException {
         final StringTokenizer tokenizer = new StringTokenizer(System.getProperty("java.class.path"), File.pathSeparator, false);
-        final Set<String> filenames = new LinkedHashSet<String>();
+        final Set<String> filenames = new LinkedHashSet<>();
 
         while (tokenizer.hasMoreTokens()) {
             final String classpathElement = tokenizer.nextToken();
@@ -165,8 +165,8 @@ public class ClasspathScanner {
 
                 } else if (classpathFile.isDirectory()) {
                     // lets go through and find all of the subfolders
-                    final Set<File> directoriesToSearch = new HashSet<File>();
-                    final Set<File> newDirectories = new HashSet<File>();
+                    final Set<File> directoriesToSearch = new HashSet<>();
+                    final Set<File> newDirectories = new HashSet<>();
                     directoriesToSearch.add(classpathFile);
                     final String basePath = classpathFile.getAbsolutePath();
 

--- a/chorus-pathscanner/src/main/java/org/chorusbdd/chorus/pathscanner/FeatureListBuilder.java
+++ b/chorus-pathscanner/src/main/java/org/chorusbdd/chorus/pathscanner/FeatureListBuilder.java
@@ -82,7 +82,7 @@ public class FeatureListBuilder {
             List<StepMacro> globalStepMacro,
             List<String> tagExpressions) {
 
-        List<FeatureToken> allFeatures = new ArrayList<FeatureToken>();
+        List<FeatureToken> allFeatures = new ArrayList<>();
 
         //FOR EACH FEATURE FILE
         for (File featureFile : featureFiles) {

--- a/chorus-pathscanner/src/main/java/org/chorusbdd/chorus/pathscanner/FilePathScanner.java
+++ b/chorus-pathscanner/src/main/java/org/chorusbdd/chorus/pathscanner/FilePathScanner.java
@@ -50,7 +50,7 @@ public class FilePathScanner {
     public static final FileFilter STEP_MACRO_FILTER = new StepMacroFileFilter();
 
     public List<File> getFeatureFiles(List<String> paths, FileFilter fileFilter) {
-        List<File> result = new ArrayList<File>();
+        List<File> result = new ArrayList<>();
         for (String fileName : paths) {
             File f = new File(fileName);
             if (f.exists()) {

--- a/chorus-pathscanner/src/main/java/org/chorusbdd/chorus/pathscanner/HandlerClassDiscovery.java
+++ b/chorus-pathscanner/src/main/java/org/chorusbdd/chorus/pathscanner/HandlerClassDiscovery.java
@@ -51,7 +51,7 @@ public class HandlerClassDiscovery {
 
     private ChorusLog log = ChorusLogFactory.getLog(HandlerClassDiscovery.class);
 
-    private Map<String, String> duplicateNameToDescription = new HashMap<String,String>();
+    private Map<String, String> duplicateNameToDescription = new HashMap<>();
 
     /**
      * Scans the classpath for handler classes
@@ -61,7 +61,7 @@ public class HandlerClassDiscovery {
      */
     public HashMap<String, Class> discoverHandlerClasses(List<String> basePackages) {
         //always include the Chorus handlers package
-        HashMap<String, Class> handlerNameToHandlerClass = new HashMap<String, Class>();
+        HashMap<String, Class> handlerNameToHandlerClass = new HashMap<>();
 
         HandlerClassFilterFactory filterFactory = new HandlerClassFilterFactory();
         ClassFilter chainStart = filterFactory.createClassFilters(basePackages);

--- a/chorus-pathscanner/src/main/java/org/chorusbdd/chorus/pathscanner/StepMacroBuilder.java
+++ b/chorus-pathscanner/src/main/java/org/chorusbdd/chorus/pathscanner/StepMacroBuilder.java
@@ -54,7 +54,7 @@ import java.util.Map;
  */
 public class StepMacroBuilder {
 
-    private Map<List<String>, List<StepMacro>> stepMacroPathsToStepMacros = new HashMap<List<String>, List<StepMacro>>();
+    private Map<List<String>, List<StepMacro>> stepMacroPathsToStepMacros = new HashMap<>();
 
     private ChorusLog log = ChorusLogFactory.getLog(StepMacroBuilder.class);
 
@@ -81,7 +81,7 @@ public class StepMacroBuilder {
     }
 
     private List<StepMacro> loadStepMacros(List<File> stepMacroFiles) {
-        List<StepMacro> macros = new ArrayList<StepMacro>();
+        List<StepMacro> macros = new ArrayList<>();
         for ( File f : stepMacroFiles) {
             macros.addAll(parseStepMacro(f));
         }

--- a/chorus-pathscanner/src/main/java/org/chorusbdd/chorus/pathscanner/TagExpressionEvaluator.java
+++ b/chorus-pathscanner/src/main/java/org/chorusbdd/chorus/pathscanner/TagExpressionEvaluator.java
@@ -103,7 +103,7 @@ public class TagExpressionEvaluator {
     }
 
     private Set<String> extractTagsFromSimpleExpression(String tagExpression) {
-        Set<String> tags = new HashSet<String>();
+        Set<String> tags = new HashSet<>();
         String[] tokens = tagExpression.split(" ");
         for (String token : tokens) {
             token = token.trim();

--- a/chorus-processes/src/main/java/org/chorusbdd/chorus/processes/manager/ProcessManagerImpl.java
+++ b/chorus-processes/src/main/java/org/chorusbdd/chorus/processes/manager/ProcessManagerImpl.java
@@ -69,7 +69,7 @@ public class ProcessManagerImpl implements ProcessManager {
 
     private ChorusLog log = ChorusLogFactory.getLog(ProcessManager.class);
 
-    private final Map<String, NamedProcessConfig> processes = new ConcurrentHashMap<String, NamedProcessConfig>();
+    private final Map<String, NamedProcessConfig> processes = new ConcurrentHashMap<>();
 
     private final CleanupShutdownHook cleanupShutdownHook = new CleanupShutdownHook();
 
@@ -165,7 +165,7 @@ public class ProcessManagerImpl implements ProcessManager {
     }
 
     public synchronized void stopAllProcesses() {
-        final Set<String> processNames = new HashSet<String>(processes.keySet());
+        final Set<String> processNames = new HashSet<>(processes.keySet());
         for (final String name : processNames) {
             stopProcess(name);
         }

--- a/chorus-processes/src/main/java/org/chorusbdd/chorus/processes/manager/commandlinebuilder/AbstractCommandLineBuilder.java
+++ b/chorus-processes/src/main/java/org/chorusbdd/chorus/processes/manager/commandlinebuilder/AbstractCommandLineBuilder.java
@@ -42,7 +42,7 @@ public abstract class AbstractCommandLineBuilder {
     public abstract List<String> buildCommandLine();
 
     protected List<String> getSpaceSeparatedTokens(String spaceSeparated) {
-        List<String> tokens = new ArrayList<String>();
+        List<String> tokens = new ArrayList<>();
         String[] j = spaceSeparated.split(" ");
         for ( String s : j ) {
             if ( s.trim().length() > 0) {

--- a/chorus-processes/src/main/java/org/chorusbdd/chorus/processes/manager/commandlinebuilder/JavaProcessCommandLineBuilder.java
+++ b/chorus-processes/src/main/java/org/chorusbdd/chorus/processes/manager/commandlinebuilder/JavaProcessCommandLineBuilder.java
@@ -69,7 +69,7 @@ public class JavaProcessCommandLineBuilder extends AbstractCommandLineBuilder {
         String mainClassToken = processInfo.getMainclass();
         List<String> argsTokens = getSpaceSeparatedTokens(processInfo.getArgs());
 
-        List<String> commandLineTokens = new ArrayList<String>();
+        List<String> commandLineTokens = new ArrayList<>();
         commandLineTokens.add(executableToken);
         commandLineTokens.addAll(jvmArgs);
         commandLineTokens.addAll(log4jTokens);
@@ -92,14 +92,14 @@ public class JavaProcessCommandLineBuilder extends AbstractCommandLineBuilder {
     }
 
     private List<String> getClasspathTokens(ProcessManagerConfig processesConfig) {
-        List<String>  classPathTokens = new ArrayList<String>();
+        List<String>  classPathTokens = new ArrayList<>();
         classPathTokens.add("-classpath");
         classPathTokens.add(processesConfig.getClasspath());
         return classPathTokens;
     }
 
     private List<String> getDebugTokens(ProcessManagerConfig processesConfig) {
-        List<String> debugTokens = new ArrayList<String>();
+        List<String> debugTokens = new ArrayList<>();
         if (processesConfig.getDebugPort() > -1) {
             debugTokens.add("-Xdebug");
             debugTokens.add(String.format("-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=%s", processesConfig.getDebugPort()));
@@ -108,7 +108,7 @@ public class JavaProcessCommandLineBuilder extends AbstractCommandLineBuilder {
     }
 
     private List<String> getJmxTokens(ProcessManagerConfig processesConfig) {
-        List<String> jmxTokens = new ArrayList<String>();
+        List<String> jmxTokens = new ArrayList<>();
         if (processesConfig.getRemotingPort() > -1) {
             jmxTokens.add("-Dcom.sun.management.jmxremote.ssl=false");
             jmxTokens.add("-Dcom.sun.management.jmxremote.authenticate=false");
@@ -119,7 +119,7 @@ public class JavaProcessCommandLineBuilder extends AbstractCommandLineBuilder {
     }
 
     private List<String> getLog4jTokens(String featureProcessName) {
-        List<String> log4jTokens = new ArrayList<String>();
+        List<String> log4jTokens = new ArrayList<>();
         File log4jConfigFile = findLog4jConfigFile();
         if ( log4jConfigFile != null && log4jConfigFile.exists()) {
             log.debug("Found log4j config at " + log4jConfigFile.getPath() + " will set -Dlog4j.configuration when starting process");

--- a/chorus-processes/src/main/java/org/chorusbdd/chorus/processes/manager/commandlinebuilder/NativeProcessCommandLineBuilder.java
+++ b/chorus-processes/src/main/java/org/chorusbdd/chorus/processes/manager/commandlinebuilder/NativeProcessCommandLineBuilder.java
@@ -61,7 +61,7 @@ public class NativeProcessCommandLineBuilder extends AbstractCommandLineBuilder 
         String executableToken = getExecutableToken(namedProcessConfig);
         List<String> argsTokens = getSpaceSeparatedTokens(namedProcessConfig.getArgs());
 
-        List<String> commandLineTokens = new ArrayList<String>();
+        List<String> commandLineTokens = new ArrayList<>();
         commandLineTokens.add(executableToken);
         commandLineTokens.addAll(argsTokens);
         return commandLineTokens;

--- a/chorus-remoting/src/main/java/org/chorusbdd/chorus/remoting/jmx/remotingmanager/JmxRemotingManager.java
+++ b/chorus-remoting/src/main/java/org/chorusbdd/chorus/remoting/jmx/remotingmanager/JmxRemotingManager.java
@@ -64,7 +64,7 @@ public class JmxRemotingManager implements RemotingManager {
     /**
      * Map: configName -> proxy
      */
-    private final Map<String, ChorusHandlerJmxProxy> proxies = new HashMap<String, ChorusHandlerJmxProxy>();
+    private final Map<String, ChorusHandlerJmxProxy> proxies = new HashMap<>();
 
     private final RemotingConfigBeanValidator configValidator = new RemotingConfigBeanValidator();
 
@@ -133,7 +133,7 @@ public class JmxRemotingManager implements RemotingManager {
 
     @Override
     public List<StepInvoker> getStepInvokers() {
-        List<StepInvoker> invokers = new LinkedList<StepInvoker>();
+        List<StepInvoker> invokers = new LinkedList<>();
         for ( List<StepInvoker> l : remoteInvokersToUse.values()) {
             invokers.addAll(l);
         }

--- a/chorus-remoting/src/main/java/org/chorusbdd/chorus/remoting/jmx/serialization/AbstractJmxResult.java
+++ b/chorus-remoting/src/main/java/org/chorusbdd/chorus/remoting/jmx/serialization/AbstractJmxResult.java
@@ -54,7 +54,7 @@ public class AbstractJmxResult implements Serializable {
 
     //Using a Map to store field data because it might help to support backwards compatibility
     //we may be able to add more fields and still deserialize earlier versions of JmxStepResult
-    private Map<String, Object> fieldMap = new HashMap<String, Object>();
+    private Map<String, Object> fieldMap = new HashMap<>();
 
     public Object get(Object key) {
         return fieldMap.get(key);

--- a/chorus-results/src/main/java/org/chorusbdd/chorus/results/FeatureToken.java
+++ b/chorus-results/src/main/java/org/chorusbdd/chorus/results/FeatureToken.java
@@ -57,7 +57,7 @@ public class FeatureToken extends AbstractToken implements PassPendingFailToken 
     private List<String> allConfigurationNames = Collections.singletonList(BASE_CONFIGURATION);
 
     private StringBuilder description = new StringBuilder();
-    private List<ScenarioToken> scenarios = new ArrayList<ScenarioToken>();
+    private List<ScenarioToken> scenarios = new ArrayList<>();
     private transient File featureFile;
 
     private String unavailableHandlersMessage;
@@ -220,7 +220,7 @@ public class FeatureToken extends AbstractToken implements PassPendingFailToken 
         copy.name = this.name;
         copy.usesHandlers = usesHandlers.clone();
         copy.configurationName = this.configurationName;
-        copy.scenarios = new ArrayList<ScenarioToken>(this.scenarios.size());
+        copy.scenarios = new ArrayList<>(this.scenarios.size());
         copy.featureFile = featureFile;
         for (ScenarioToken scenario : this.scenarios) {
             copy.scenarios.add(scenario.deepCopy());

--- a/chorus-results/src/main/java/org/chorusbdd/chorus/results/ScenarioToken.java
+++ b/chorus-results/src/main/java/org/chorusbdd/chorus/results/ScenarioToken.java
@@ -53,8 +53,8 @@ public class ScenarioToken extends AbstractToken implements PassPendingFailToken
     private static final long serialVersionUID = 3;
 
     private String name;
-    private List<StepToken> steps = new ArrayList<StepToken>();
-    private List<String> tags = new ArrayList<String>();//all tags listed on this scenario and its parent feature
+    private List<StepToken> steps = new ArrayList<>();
+    private List<String> tags = new ArrayList<>();//all tags listed on this scenario and its parent feature
 
     public ScenarioToken() {
         super(getNextId());
@@ -119,11 +119,11 @@ public class ScenarioToken extends AbstractToken implements PassPendingFailToken
         ScenarioToken copy = new ScenarioToken(getNextId());
         super.deepCopy(copy);
         copy.name = this.name;
-        copy.steps = new ArrayList<StepToken>();
+        copy.steps = new ArrayList<>();
         for (StepToken step : steps) {
             copy.steps.add(step.deepCopy());
         }
-        copy.tags = new ArrayList<String>();
+        copy.tags = new ArrayList<>();
         copy.tags.addAll(this.tags);
         return copy;
     }

--- a/chorus-results/src/main/java/org/chorusbdd/chorus/results/StepToken.java
+++ b/chorus-results/src/main/java/org/chorusbdd/chorus/results/StepToken.java
@@ -50,7 +50,7 @@ public class StepToken extends AbstractToken {
     /**
      * Step macro are composite steps which contain child steps
      */
-    private List<StepToken> childSteps = new ArrayList<StepToken>();
+    private List<StepToken> childSteps = new ArrayList<>();
 
     private long timeTaken = 0;  //time taken to run the step
 
@@ -175,7 +175,7 @@ public class StepToken extends AbstractToken {
     }
 
     private List<StepToken> recursiveCopy(List<StepToken> childSteps) {
-        List<StepToken> l = new ArrayList<StepToken>();
+        List<StepToken> l = new ArrayList<>();
         for ( StepToken t : childSteps) {
             l.add(t.deepCopy());
         }

--- a/chorus-results/src/test/junit/org/chorusbdd/chorus/results/TestTokenVisitor.java
+++ b/chorus-results/src/test/junit/org/chorusbdd/chorus/results/TestTokenVisitor.java
@@ -84,11 +84,11 @@ public class TestTokenVisitor extends Assert {
 
         private int visitations;
 
-        private List<Token> expectedTokenOrder = new LinkedList<Token>(
-        Arrays.asList(
-            (Token)executionToken, executionToken.getResultsSummary(), featureToken, scenarioToken, stepOne, stepTwo,
-            scenarioTwo, stepThree, featureTwo
-        ));
+        private List<Token> expectedTokenOrder = new LinkedList<>(
+                Arrays.asList(
+                        (Token) executionToken, executionToken.getResultsSummary(), featureToken, scenarioToken, stepOne, stepTwo,
+                        scenarioTwo, stepThree, featureTwo
+                ));
 
         public void visit(ExecutionToken executionToken) {
             checkExpectedToken(executionToken);

--- a/chorus-selftest/src/test/features/org/chorusbdd/chorus/selftest/remoting/jmx/remotingwithlocalprocess/BillAndBenHandler.java
+++ b/chorus-selftest/src/test/features/org/chorusbdd/chorus/selftest/remoting/jmx/remotingwithlocalprocess/BillAndBenHandler.java
@@ -47,7 +47,7 @@ public class BillAndBenHandler implements StepInvokerProvider {
 
     @Override
     public List<StepInvoker> getStepInvokers() {
-        List<StepInvoker> l = new LinkedList<StepInvoker>();
+        List<StepInvoker> l = new LinkedList<>();
         StepInvoker one = new StepInvoker() {
 
             String regex = "I can call a step method exported by the " + jmxProperty + " handler";

--- a/chorus-spring/src/main/java/org/chorusbdd/chorus/spring/SpringContextInjector.java
+++ b/chorus-spring/src/main/java/org/chorusbdd/chorus/spring/SpringContextInjector.java
@@ -62,7 +62,7 @@ public class SpringContextInjector implements SpringInjector {
      * n.b. Nick, I am guessing the reason for storing in this map may be to retain a strong reference to the context until we
      * explicitly clear down after the scenario, since I couldn't find another obvious reason
      */
-    private Map<Object, ContextWithURL> springContextByCreatingHandler = new HashMap<Object, ContextWithURL>();
+    private Map<Object, ContextWithURL> springContextByCreatingHandler = new HashMap<>();
 
     public void injectSpringContext(Object handler, FeatureToken featureToken, String contextFileName) {
         Class handlerClass = handler.getClass();

--- a/chorus-spring/src/test/features/org/chorusbdd/chorus/spring/selftest/calculator/Calculator.java
+++ b/chorus-spring/src/test/features/org/chorusbdd/chorus/spring/selftest/calculator/Calculator.java
@@ -41,7 +41,7 @@ public class Calculator {
         ADD, SUBTRACT, MULTIPLY, DIVIDE
     }
 
-    private Stack<Double> stack = new Stack<Double>();
+    private Stack<Double> stack = new Stack<>();
 
     private double lastResult = 0;
 

--- a/chorus-stepinvoker/src/main/java/org/chorusbdd/chorus/stepinvoker/CompositeStepInvokerProvider.java
+++ b/chorus-stepinvoker/src/main/java/org/chorusbdd/chorus/stepinvoker/CompositeStepInvokerProvider.java
@@ -39,7 +39,7 @@ import java.util.List;
  */
 public class CompositeStepInvokerProvider implements StepInvokerProvider {
 
-    private List<StepInvokerProvider> childInvokers = new LinkedList<StepInvokerProvider>();
+    private List<StepInvokerProvider> childInvokers = new LinkedList<>();
 
     public CompositeStepInvokerProvider() {
         this(Collections.EMPTY_LIST);
@@ -55,7 +55,7 @@ public class CompositeStepInvokerProvider implements StepInvokerProvider {
 
     @Override
     public List<StepInvoker> getStepInvokers() {
-        List<StepInvoker> invokerList = new LinkedList<StepInvoker>();
+        List<StepInvoker> invokerList = new LinkedList<>();
         for ( StepInvokerProvider p : childInvokers) {
             invokerList.addAll(p.getStepInvokers());
         }

--- a/chorus-stepinvoker/src/main/java/org/chorusbdd/chorus/stepinvoker/HandlerClassInvokerFactory.java
+++ b/chorus-stepinvoker/src/main/java/org/chorusbdd/chorus/stepinvoker/HandlerClassInvokerFactory.java
@@ -56,7 +56,7 @@ public class HandlerClassInvokerFactory implements StepInvokerProvider {
     }
 
     public List<StepInvoker> getStepInvokers() {
-        List<StepInvoker> stepInvokers = new ArrayList<StepInvoker>();
+        List<StepInvoker> stepInvokers = new ArrayList<>();
 
         //if the handler implements StepInvokerProvider then get the step invokers directly
         //these invokers may change at any point in the scenario lifecycle, even between steps
@@ -93,7 +93,7 @@ public class HandlerClassInvokerFactory implements StepInvokerProvider {
     }
 
     private List<StepInvoker> getStepInvokersForAnnotatedMethods() {
-        List<StepInvoker> stepInvokers = new ArrayList<StepInvoker>();
+        List<StepInvoker> stepInvokers = new ArrayList<>();
         Method[] methods = handlerInstance.getClass().getMethods();
         for (Method method : methods) {
             //only check methods with Step annotation

--- a/chorus-util/src/main/java/org/chorusbdd/chorus/util/function/Tuple2.java
+++ b/chorus-util/src/main/java/org/chorusbdd/chorus/util/function/Tuple2.java
@@ -51,6 +51,6 @@ public class Tuple2<K,V> {
     }
 
     public static <K,V> Tuple2<K,V> tuple2(K k, V v) {
-        return new Tuple2<K,V>(k, v);
+        return new Tuple2<>(k, v);
     }
 }

--- a/chorus-util/src/main/java/org/chorusbdd/chorus/util/function/Tuple3.java
+++ b/chorus-util/src/main/java/org/chorusbdd/chorus/util/function/Tuple3.java
@@ -55,6 +55,6 @@ public class Tuple3<A,B,C> {
     public C getThree() { return c; }
 
     public static <A,B,C> Tuple3<A,B,C> tuple3(A a, B b, C c) {
-        return new Tuple3<A,B,C>(a,b,c);
+        return new Tuple3<>(a, b, c);
     }
 }

--- a/chorus/src/main/java/org/chorusbdd/chorus/ant/ChorusTask.java
+++ b/chorus/src/main/java/org/chorusbdd/chorus/ant/ChorusTask.java
@@ -56,7 +56,7 @@ import java.util.List;
 public class ChorusTask extends Task {
 
     private String handlerBasePackages;
-    private List<File> featureFiles = new ArrayList<File>();
+    private List<File> featureFiles = new ArrayList<>();
     private boolean verbose;
     private boolean failOnTestFailure;
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2293 - “The diamond operator ("<>") should be used ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2293
Please let me know if you have any questions.
Ayman Abdelghany.