### PR TITLE
 Resources should be closed

### DIFF
--- a/chorus-pathscanner/src/main/java/org/chorusbdd/chorus/pathscanner/ClasspathScanner.java
+++ b/chorus-pathscanner/src/main/java/org/chorusbdd/chorus/pathscanner/ClasspathScanner.java
@@ -162,7 +162,8 @@ public class ClasspathScanner {
                             filenames.add(entry.getName());
                         }
                     }
-
+                    zip.close();
+                    
                 } else if (classpathFile.isDirectory()) {
                     // lets go through and find all of the subfolders
                     final Set<File> directoriesToSearch = new HashSet<File>();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2095 - “Resources should be closed”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2095
Please let me know if you have any questions.
Ayman Abdelghany.